### PR TITLE
Include shipment with orders

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -83,16 +83,33 @@ func (s *BCClient) GetAndUnmarshal(endpoint string, outData interface{}) error {
 		return err
 	}
 
+	return s.doUnmarshalling(req, outData)
+}
+
+func (s *BCClient) doUnmarshalling(req *http.Request, outData interface{}) error {
 	res, err := s.DoRequest(req)
 	if err != nil {
 		return err
 	}
 
-	err = json.Unmarshal(res, outData)
+	if len(res) > 0 {
+		err = json.Unmarshal(res, outData)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetAndUnmarshal - gets the request body of a plain url and unmarshals to passed in struct pointer
+//
+// Example of the endpoint parameter would be "/v2/orders/" and the client will handle the store key and base url pieces
+func (s *BCClient) GetAndUnmarshalRaw(fullEndpoint string, outData interface{}) error {
+	req, err := http.NewRequest("GET", fullEndpoint, nil)
 	if err != nil {
 		return err
 	}
-	return nil
+	return s.doUnmarshalling(req, outData)
 }
 
 // GetAndUnmarshalWithQuery - gets the request body of the url with a query string added on and unmarshals to passed in struct pointer
@@ -105,14 +122,5 @@ func (s *BCClient) GetAndUnmarshalWithQuery(endpoint string, rawQuery string, ou
 	}
 	req.URL.RawQuery = rawQuery
 
-	res, err := s.DoRequest(req)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(res, outData)
-	if err != nil {
-		return err
-	}
-	return nil
+	return s.doUnmarshalling(req, outData)
 }

--- a/connect/client.go
+++ b/connect/client.go
@@ -126,3 +126,13 @@ func (s *BCClient) GetAndUnmarshalWithQuery(endpoint string, rawQuery string, ou
 
 	return s.doUnmarshalling(req, outData)
 }
+
+type Client interface {
+	SetBaseURL(url string)
+	DoRequest(req *http.Request) ([]byte, error)
+	GetBody(url string) (body []byte, err error)
+	BuildUrlRequest(endpoint string) (req *http.Request, err error)
+	GetAndUnmarshal(endpoint string, outData interface{}) error
+	GetAndUnmarshalRaw(fullEndpoint string, outData interface{}) error
+	GetAndUnmarshalWithQuery(endpoint string, rawQuery string, outData interface{}) error
+}

--- a/connect/client.go
+++ b/connect/client.go
@@ -101,9 +101,11 @@ func (s *BCClient) doUnmarshalling(req *http.Request, outData interface{}) error
 	return nil
 }
 
-// GetAndUnmarshal - gets the request body of a plain url and unmarshals to passed in struct pointer
+// GetAndUnmarshalRaw - gets the request body of a full plain bigcommerce url and unmarshals to passed in struct pointer
 //
-// Example of the endpoint parameter would be "/v2/orders/" and the client will handle the store key and base url pieces
+// Example of the fullEndpoint parameter would be "https://api.bigcommerce.com/stores/{{YOUR-STORE-KEY}}/v2/orders/12039/products"
+// the client will not manipulate the endpoint in any way.
+// This function is used by things like Resource.EagerGet
 func (s *BCClient) GetAndUnmarshalRaw(fullEndpoint string, outData interface{}) error {
 	req, err := http.NewRequest("GET", fullEndpoint, nil)
 	if err != nil {

--- a/order/order.go
+++ b/order/order.go
@@ -1,7 +1,6 @@
 package order
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/dan-collins/biggommerce/primative"
@@ -74,6 +73,7 @@ type Order struct {
 	ShippingAddresses                       []ShippingAddress
 	CouponResource                          Resource `json:"coupons,omitempty"`
 	Coupons                                 []Coupon
+	Shipments                               []Shipment
 	ExternalID                              interface{} `json:"external_id"`
 	ExternalMerchantID                      interface{} `json:"external_merchant_id"`
 	TaxProviderID                           string      `json:"tax_provider_id,omitempty"`
@@ -116,12 +116,9 @@ type Query struct {
 // EagerGet - attempts to unmarshal a resource url into an interface, preferably one intended to unmarshal the json body of that url.
 func (r Resource) EagerGet(s *Client, i interface{}) error {
 	url := r.URL
-	body, err := s.GetBody(url)
+	err := s.GetAndUnmarshalRaw(url, &i)
 	if err != nil {
 		return err
 	}
-	if len(body) > 0 {
-		err = json.Unmarshal(body, i)
-	}
-	return err
+	return nil
 }

--- a/order/order.go
+++ b/order/order.go
@@ -8,70 +8,70 @@ import (
 
 // Order is a struct that represents the return body of BigCommerce GET /orders
 type Order struct {
-	ID                                      int64            `json:"id,omitempty"`
-	CustomerID                              int64            `json:"customer_id,omitempty"`
-	DateCreated                             primative.BCDate `json:"date_created,omitempty"`
-	DateModified                            primative.BCDate `json:"date_modified,omitempty"`
-	DateShipped                             primative.BCDate `json:"date_shipped,omitempty"`
-	StatusID                                int64            `json:"status_id,omitempty"`
-	Status                                  string           `json:"status,omitempty"`
-	SubtotalExTax                           float64          `json:"subtotal_ex_tax,string"`
-	SubtotalIncTax                          float64          `json:"subtotal_inc_tax,string"`
-	SubtotalTax                             float64          `json:"subtotal_tax,string"`
-	BaseShippingCost                        float64          `json:"base_shipping_cost,string"`
-	ShippingCostExTax                       float64          `json:"shipping_cost_ex_tax,string"`
-	ShippingCostIncTax                      float64          `json:"shipping_cost_inc_tax,string"`
-	ShippingCostTax                         float64          `json:"shipping_cost_tax,string"`
-	ShippingCostTaxClassID                  int64            `json:"shipping_cost_tax_class_id,omitempty"`
-	BaseHandlingCost                        float64          `json:"base_handling_cost,string"`
-	HandlingCostExTax                       float64          `json:"handling_cost_ex_tax,string"`
-	HandlingCostIncTax                      float64          `json:"handling_cost_inc_tax,string"`
-	HandlingCostTax                         float64          `json:"handling_cost_tax,string"`
-	HandlingCostTaxClassID                  int64            `json:"handling_cost_tax_class_id,omitempty"`
-	BaseWrappingCost                        float64          `json:"base_wrapping_cost,string"`
-	WrappingCostExTax                       float64          `json:"wrapping_cost_ex_tax,string"`
-	WrappingCostIncTax                      float64          `json:"wrapping_cost_inc_tax,string"`
-	WrappingCostTax                         float64          `json:"wrapping_cost_tax,string"`
-	WrappingCostTaxClassID                  int64            `json:"wrapping_cost_tax_class_id,omitempty"`
-	TotalExTax                              float64          `json:"total_ex_tax,string"`
-	TotalIncTax                             float64          `json:"total_inc_tax,string"`
-	TotalTax                                float64          `json:"total_tax,string"`
-	ItemsTotal                              int64            `json:"items_total,omitempty"`
-	ItemsShipped                            int64            `json:"items_shipped,omitempty"`
-	PaymentMethod                           string           `json:"payment_method,omitempty"`
-	PaymentProviderID                       string           `json:"payment_provider_id,omitempty"`
-	PaymentStatus                           string           `json:"payment_status,omitempty"`
-	RefundedAmount                          float64          `json:"refunded_amount,string"`
-	OrderIsDigital                          bool             `json:"order_is_digital,omitempty"`
-	StoreCreditAmount                       float64          `json:"store_credit_amount,string"`
-	GiftCertificateAmount                   float64          `json:"gift_certificate_amount,string"`
-	IPAddress                               string           `json:"ip_address,omitempty"`
-	GeoipCountry                            string           `json:"geoip_country,omitempty"`
-	GeoipCountryIso2                        string           `json:"geoip_country_iso2,omitempty"`
-	CurrencyID                              int64            `json:"currency_id,omitempty"`
-	CurrencyCode                            string           `json:"currency_code,omitempty"`
-	CurrencyExchangeRate                    string           `json:"currency_exchange_rate,omitempty"`
-	DefaultCurrencyID                       int64            `json:"default_currency_id,omitempty"`
-	DefaultCurrencyCode                     string           `json:"default_currency_code,omitempty"`
-	StaffNotes                              string           `json:"staff_notes,omitempty"`
-	CustomerMessage                         string           `json:"customer_message,omitempty"`
-	DiscountAmount                          float64          `json:"discount_amount,string"`
-	CouponDiscount                          float64          `json:"coupon_discount,string"`
-	ShippingAddressCount                    int64            `json:"shipping_address_count,omitempty"`
-	IsDeleted                               bool             `json:"is_deleted,omitempty"`
-	EbayOrderID                             string           `json:"ebay_order_id,omitempty"`
-	CartID                                  string           `json:"cart_id,omitempty"`
-	BillingAddress                          Address          `json:"billing_address,omitempty"`
-	IsEmailOptIn                            bool             `json:"is_email_opt_in,omitempty"`
-	CreditCardType                          interface{}      `json:"credit_card_type"`
-	OrderSource                             string           `json:"order_source,omitempty"`
-	ChannelID                               int64            `json:"channel_id,omitempty"`
-	ExternalSource                          interface{}      `json:"external_source"`
-	ProductResource                         Resource         `json:"products,omitempty"`
+	ID                                      int64              `json:"id,omitempty"`
+	CustomerID                              int64              `json:"customer_id,omitempty"`
+	DateCreated                             primative.BCDate   `json:"date_created,omitempty"`
+	DateModified                            primative.BCDate   `json:"date_modified,omitempty"`
+	DateShipped                             primative.BCDate   `json:"date_shipped,omitempty"`
+	StatusID                                int64              `json:"status_id,omitempty"`
+	Status                                  string             `json:"status,omitempty"`
+	SubtotalExTax                           float64            `json:"subtotal_ex_tax,string"`
+	SubtotalIncTax                          float64            `json:"subtotal_inc_tax,string"`
+	SubtotalTax                             float64            `json:"subtotal_tax,string"`
+	BaseShippingCost                        float64            `json:"base_shipping_cost,string"`
+	ShippingCostExTax                       float64            `json:"shipping_cost_ex_tax,string"`
+	ShippingCostIncTax                      float64            `json:"shipping_cost_inc_tax,string"`
+	ShippingCostTax                         float64            `json:"shipping_cost_tax,string"`
+	ShippingCostTaxClassID                  int64              `json:"shipping_cost_tax_class_id,omitempty"`
+	BaseHandlingCost                        float64            `json:"base_handling_cost,string"`
+	HandlingCostExTax                       float64            `json:"handling_cost_ex_tax,string"`
+	HandlingCostIncTax                      float64            `json:"handling_cost_inc_tax,string"`
+	HandlingCostTax                         float64            `json:"handling_cost_tax,string"`
+	HandlingCostTaxClassID                  int64              `json:"handling_cost_tax_class_id,omitempty"`
+	BaseWrappingCost                        float64            `json:"base_wrapping_cost,string"`
+	WrappingCostExTax                       float64            `json:"wrapping_cost_ex_tax,string"`
+	WrappingCostIncTax                      float64            `json:"wrapping_cost_inc_tax,string"`
+	WrappingCostTax                         float64            `json:"wrapping_cost_tax,string"`
+	WrappingCostTaxClassID                  int64              `json:"wrapping_cost_tax_class_id,omitempty"`
+	TotalExTax                              float64            `json:"total_ex_tax,string"`
+	TotalIncTax                             float64            `json:"total_inc_tax,string"`
+	TotalTax                                float64            `json:"total_tax,string"`
+	ItemsTotal                              int64              `json:"items_total,omitempty"`
+	ItemsShipped                            int64              `json:"items_shipped,omitempty"`
+	PaymentMethod                           string             `json:"payment_method,omitempty"`
+	PaymentProviderID                       string             `json:"payment_provider_id,omitempty"`
+	PaymentStatus                           string             `json:"payment_status,omitempty"`
+	RefundedAmount                          float64            `json:"refunded_amount,string"`
+	OrderIsDigital                          bool               `json:"order_is_digital,omitempty"`
+	StoreCreditAmount                       float64            `json:"store_credit_amount,string"`
+	GiftCertificateAmount                   float64            `json:"gift_certificate_amount,string"`
+	IPAddress                               string             `json:"ip_address,omitempty"`
+	GeoipCountry                            string             `json:"geoip_country,omitempty"`
+	GeoipCountryIso2                        string             `json:"geoip_country_iso2,omitempty"`
+	CurrencyID                              int64              `json:"currency_id,omitempty"`
+	CurrencyCode                            string             `json:"currency_code,omitempty"`
+	CurrencyExchangeRate                    string             `json:"currency_exchange_rate,omitempty"`
+	DefaultCurrencyID                       int64              `json:"default_currency_id,omitempty"`
+	DefaultCurrencyCode                     string             `json:"default_currency_code,omitempty"`
+	StaffNotes                              string             `json:"staff_notes,omitempty"`
+	CustomerMessage                         string             `json:"customer_message,omitempty"`
+	DiscountAmount                          float64            `json:"discount_amount,string"`
+	CouponDiscount                          float64            `json:"coupon_discount,string"`
+	ShippingAddressCount                    int64              `json:"shipping_address_count,omitempty"`
+	IsDeleted                               bool               `json:"is_deleted,omitempty"`
+	EbayOrderID                             string             `json:"ebay_order_id,omitempty"`
+	CartID                                  string             `json:"cart_id,omitempty"`
+	BillingAddress                          Address            `json:"billing_address,omitempty"`
+	IsEmailOptIn                            bool               `json:"is_email_opt_in,omitempty"`
+	CreditCardType                          interface{}        `json:"credit_card_type"`
+	OrderSource                             string             `json:"order_source,omitempty"`
+	ChannelID                               int64              `json:"channel_id,omitempty"`
+	ExternalSource                          interface{}        `json:"external_source"`
+	ProductResource                         primative.Resource `json:"products,omitempty"`
 	Products                                []OrderProduct
-	ShippingResource                        Resource `json:"shipping_addresses,omitempty"`
+	ShippingResource                        primative.Resource `json:"shipping_addresses,omitempty"`
 	ShippingAddresses                       []ShippingAddress
-	CouponResource                          Resource `json:"coupons,omitempty"`
+	CouponResource                          primative.Resource `json:"coupons,omitempty"`
 	Coupons                                 []Coupon
 	Shipments                               []Shipment
 	ExternalID                              interface{} `json:"external_id"`
@@ -80,12 +80,6 @@ type Order struct {
 	StoreDefaultCurrencyCode                string      `json:"store_default_currency_code,omitempty"`
 	StoreDefaultToTransactionalExchangeRate string      `json:"store_default_to_transactional_exchange_rate,omitempty"`
 	CustomStatus                            string      `json:"custom_status,omitempty"`
-}
-
-// Resource is general struct for resource url and type found in many returned objects from bigcommerce
-type Resource struct {
-	URL      string
-	Resource string
 }
 
 // Query struct to handle orders endpoint search query params
@@ -111,14 +105,4 @@ type Query struct {
 	MaxDateCreatedRaw  string    `url:"max_date_created,omitempty"`
 	MinDateModifiedRaw string    `url:"min_date_modified,omitempty"`
 	MaxDateModifiedRaw string    `url:"max_date_modified,omitempty"`
-}
-
-// EagerGet - attempts to unmarshal a resource url into an interface, preferably one intended to unmarshal the json body of that url.
-func (r Resource) EagerGet(s *Client, i interface{}) error {
-	url := r.URL
-	err := s.GetAndUnmarshalRaw(url, &i)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/primative/resource.go
+++ b/primative/resource.go
@@ -1,0 +1,15 @@
+package primative
+
+import "github.com/dan-collins/biggommerce/connect"
+
+// Resource is general struct for resource url and type found in many returned objects from bigcommerce
+type Resource struct {
+	URL      string
+	Resource string
+}
+
+// EagerGet - attempts to unmarshal a resource url into an interface, preferably one intended to unmarshal the json body of that url.
+func (r Resource) EagerGet(s connect.Client, i interface{}) error {
+	url := r.URL
+	return s.GetAndUnmarshalRaw(url, &i)
+}


### PR DESCRIPTION
* Moved resource into the primative package since it will potentially be used for other endpoints
* Shipments are now included with hydrated orders. 
* EagerGet and unmarshal functions now use DRY function for the unmarshalling