### PR TITLE
This should allow for full data sets returned from the BC API

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -15,15 +15,17 @@ type BCClient struct {
 	AuthClient string
 	StoreKey   string
 	BaseURL    string
+	Limit      int
 }
 
-//NewClient create a new client wrapper based on BC connection details
+//NewClient create a new client wrapper based on BC connection details, default result limit is set to 50
 func NewClient(authToken, authClient, storeKey string) *BCClient {
 	return &BCClient{
 		AuthToken:  authToken,
 		AuthClient: authClient,
 		StoreKey:   storeKey,
 		BaseURL:    baseBCURL,
+		Limit:      50,
 	}
 }
 

--- a/order/order.go
+++ b/order/order.go
@@ -82,7 +82,8 @@ type Order struct {
 	CustomStatus                            string      `json:"custom_status,omitempty"`
 }
 
-// Query struct to handle orders endpoint search query params
+// Query struct to handle orders endpoint search query params, if you want orders with a status of 0 ("incomplete" in BC)
+// you should set StatusIDIsZero to true, otherwise it will be ignored as a zero value when building the REST query
 type Query struct {
 	MinID              int       `url:"min_id,omitempty"`
 	MaxID              int       `url:"max_id,omitempty"`
@@ -91,6 +92,7 @@ type Query struct {
 	CustomerID         int       `url:"customer_id,omitempty"`
 	Email              string    `url:"email,omitempty"`
 	StatusID           int       `url:"status_id,omitempty"`
+	StatusIDIsZero     bool      `url:"-"`
 	CartID             string    `url:"cart_id,omitempty"`
 	PaymentMethod      string    `url:"payment_method,omitempty"`
 	MinDateCreated     time.Time `url:"-"`

--- a/primative/date.go
+++ b/primative/date.go
@@ -13,6 +13,9 @@ type BCDate struct {
 // UnmarshalJSON will unmarshall date into time object
 func (bcD *BCDate) UnmarshalJSON(input []byte) error {
 	strTime := strings.Trim(string(input), `"`)
+	if strTime == "" || strTime == "null" || strTime == `""` {
+		return nil
+	}
 	newTime, err := time.Parse(time.RFC1123Z, strTime)
 	if err != nil {
 		return err


### PR DESCRIPTION
This will assume that if a page is not provided in the order query, that the caller is requesting the entire data set. 